### PR TITLE
Browser compatibilities upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2687,8 +2687,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "dedent": {
       "version": "0.7.0",
@@ -4577,11 +4576,6 @@
         "binary-extensions": "^2.0.0"
       }
     },
-    "is-browser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-browser/-/is-browser-2.1.0.tgz",
-      "integrity": "sha512-F5rTJxDQ2sW81fcfOR1GnCXT6sVJC104fCyfj+mjpwNEwaPYSn5fte5jiHmBg3DHsIoL/l8Kvw5VN5SsTRcRFQ=="
-    },
     "is-buffer": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
@@ -4686,6 +4680,11 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
     },
     "is-number": {
       "version": "7.0.0",
@@ -7118,6 +7117,16 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "query-string": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.1.tgz",
+      "integrity": "sha512-g6y0Lbq10a5pPQpjlFuojfMfV1Pd2Jw9h75ypiYPPia3Gcq2rgkKiIwbkS6JxH7c5f5u/B/sB+d13PU+g1eu4Q==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -8192,6 +8201,11 @@
       "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
       "dev": true
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -8369,6 +8383,11 @@
           "dev": true
         }
       }
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-argv": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "caseless": "^0.12.0",
     "get-headers": "^1.0.5",
     "is-array-buffer": "^1.0.1",
-    "is-browser": "^2.1.0",
+    "is-in-browser": "^1.1.3",
+    "query-string": "^6.8.1",
     "xhr2": "^0.2.0"
   },
   "devDependencies": {

--- a/source/factory.js
+++ b/source/factory.js
@@ -1,4 +1,4 @@
-const isBrowser = require("is-browser");
+const isBrowser = require("is-in-browser").default;
 
 function createNewRequest() {
     if (!isBrowser) {

--- a/source/request.js
+++ b/source/request.js
@@ -1,7 +1,7 @@
-const { URL: NodeURL } = require("url");
 const caseless = require("caseless");
-const isBrowser = require("is-browser");
 const { parse: parseHeaders } = require("get-headers");
+const queryString = require("query-string");
+const isBrowser = require("is-in-browser").default;
 const isArrayBuffer = require("is-array-buffer/dist/is-array-buffer.common.js");
 const { createNewRequest } = require("./factory.js");
 const { ERR_ABORTED, ERR_REQUEST_FAILED } = require("./symbols.js");
@@ -40,13 +40,6 @@ function deriveResponseType(xhr) {
         return "json";
     }
     return "text";
-}
-
-function getURLConstructor() {
-    if (isBrowser) {
-        return URL;
-    }
-    return NodeURL;
 }
 
 function prepareAdditionalHeaders(requestOptions, headersHelper) {
@@ -125,12 +118,8 @@ function processResponse(xhr, options) {
 
 function processURL(originalURL, query) {
     if (query) {
-        const URLInst = getURLConstructor();
-        const url = new URLInst(originalURL);
-        Object.keys(query).forEach(qsk => {
-            url.searchParams.set(qsk, query[qsk]);
-        });
-        return url.href;
+        const processedQueryString = queryString.stringify(query);
+        return processedQueryString ? `${originalURL}?${processedQueryString}` : originalURL;
     }
     return originalURL;
 }


### PR DESCRIPTION
Remove `is-browser` package, and remove calls to Node's `URL` library. Use `query-string` and `is-in-browser` instead.