### PR TITLE
Covert header keys to lower case

### DIFF
--- a/source/headers.js
+++ b/source/headers.js
@@ -1,0 +1,32 @@
+const { parse: parseRawHeaders } = require("get-headers");
+
+/**
+ * Convert all object keys to lower case
+ * @param {Object} obj Target object
+ * @returns {Object}
+ * @private
+ */
+function keysToLower(obj) {
+    return Object.keys(obj).reduce(
+        (output, key) =>
+            Object.assign(output, {
+                [key.toLowerCase()]: obj[key]
+            }),
+        {}
+    );
+}
+
+/**
+ * Parse response headers
+ * @param {String} headersPayload The bytestring containing the headers
+ * @returns {Object} Parsed key-value headers
+ * @private
+ */
+function parseHeaders(headersPayload) {
+    const headers = parseRawHeaders(headersPayload);
+    return keysToLower(headers);
+}
+
+module.exports = {
+    parseHeaders
+};

--- a/source/request.js
+++ b/source/request.js
@@ -1,9 +1,9 @@
 const caseless = require("caseless");
-const { parse: parseHeaders } = require("get-headers");
 const queryString = require("query-string");
 const isBrowser = require("is-in-browser").default;
 const isArrayBuffer = require("is-array-buffer/dist/is-array-buffer.common.js");
 const { createNewRequest } = require("./factory.js");
+const { parseHeaders } = require("./headers.js");
 const { ERR_ABORTED, ERR_REQUEST_FAILED } = require("./symbols.js");
 const { STATUSES } = require("./status.js");
 

--- a/test/node/specs/headers.spec.js
+++ b/test/node/specs/headers.spec.js
@@ -1,0 +1,25 @@
+const { parseHeaders } = require("../../../source/headers.js");
+
+describe("headers", function() {
+    describe("parseHeaders", function() {
+        it("parses headers", function() {
+            const headers = parseHeaders(
+                ["content-type: text/html; charset=utf-8", "connection: keep-alive"].join("\r\n")
+            );
+            expect(headers).to.deep.equal({
+                "content-type": "text/html; charset=utf-8",
+                connection: "keep-alive"
+            });
+        });
+
+        it("converts header keys to lowercase", function() {
+            const headers = parseHeaders(
+                ["Www-Authenticate: Bearer xxxx", "Vary: Origin, X-Origin"].join("\r\n")
+            );
+            expect(headers).to.deep.equal({
+                "www-authenticate": "Bearer xxxx",
+                vary: "Origin, X-Origin"
+            });
+        });
+    });
+});

--- a/test/node/specs/request.spec.js
+++ b/test/node/specs/request.spec.js
@@ -4,7 +4,7 @@ const isBuffer = require("is-buffer");
 const { STATUSES } = require("../../../source/status.js");
 const { request } = require("../../../source/request.js");
 
-describe("request.js", function() {
+describe("request", function() {
     let server, putData;
 
     before(function() {

--- a/test/web/specs/headers.spec.js
+++ b/test/web/specs/headers.spec.js
@@ -1,0 +1,25 @@
+const { parseHeaders } = require("../../../source/headers.js");
+
+describe("headers", function() {
+    describe("parseHeaders", function() {
+        it("parses headers", function() {
+            const headers = parseHeaders(
+                ["content-type: text/html; charset=utf-8", "connection: keep-alive"].join("\r\n")
+            );
+            expect(headers).to.deep.equal({
+                "content-type": "text/html; charset=utf-8",
+                connection: "keep-alive"
+            });
+        });
+
+        it("converts header keys to lowercase", function() {
+            const headers = parseHeaders(
+                ["Www-Authenticate: Bearer xxxx", "Vary: Origin, X-Origin"].join("\r\n")
+            );
+            expect(headers).to.deep.equal({
+                "www-authenticate": "Bearer xxxx",
+                vary: "Origin, X-Origin"
+            });
+        });
+    });
+});

--- a/test/web/specs/request.spec.js
+++ b/test/web/specs/request.spec.js
@@ -3,7 +3,7 @@ const joinURL = require("url-join");
 const isBuffer = require("is-buffer");
 const { request } = require("../../../source/index.js");
 
-describe("request.js", function() {
+describe("request", function() {
     describe("request", function() {
         it("can get JSON by default", function() {
             return request(joinURL(SERVER_URL, "/get/json")).then(result => {


### PR DESCRIPTION
All response headers, when parsed, should have lower case keys. This PR enforces that.